### PR TITLE
Auto create playlists from folders

### DIFF
--- a/Sources/Media Library/MediaLibraryService.swift
+++ b/Sources/Media Library/MediaLibraryService.swift
@@ -543,6 +543,9 @@ extension MediaLibraryService: VLCMediaLibraryDelegate {
             $0.medialibrary?(self, didAddVideos: videos)
             $0.medialibrary?(self, didAddTracks: tracks)
         }
+
+        // Auto-create/update folder-based playlists
+        autoCreateFolderPlaylists(for: media)
     }
 
     func medialibrary(_ medialibrary: VLCMediaLibrary, didModifyMediaWithIds mediaIds: [NSNumber]) {
@@ -591,6 +594,59 @@ extension MediaLibraryService: VLCMediaLibraryDelegate {
         observable.notifyObservers {
             $0.medialibrary?(self, thumbnailReady: media,
                              type: type, success: success)
+        }
+    }
+}
+
+// MARK: - Auto folder playlists
+private extension MediaLibraryService {
+    func autoCreateFolderPlaylists(for media: [VLCMLMedia]) {
+        guard let documentPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first else {
+            return
+        }
+
+        for item in media {
+            // Resolve file URL and ensure it belongs to Documents
+            guard let fileURL = item.mainFile()?.mrl, fileURL.isFileURL else { continue }
+            let absolutePath = fileURL.path
+            guard absolutePath.hasPrefix(documentPath) else { continue }
+
+            // Compute top-level folder name under Documents
+            let relativePath = String(absolutePath.dropFirst(documentPath.count))
+            // Split and skip empty components (leading '/')
+            let pathComponents = relativePath.split(separator: "/").map(String.init)
+            // We only create playlists for files inside a folder (not at root)
+            guard pathComponents.count >= 2 else { continue }
+            let topLevelFolderName = pathComponents[0]
+
+            // Skip system/hidden folders
+            if shouldExcludeFolderFromAutoPlaylist(topLevelFolderName) { continue }
+
+            // Find or create the playlist for this folder
+            let playlist: VLCMLPlaylist?
+            if let existing = medialib.searchPlaylists(byName: topLevelFolderName, of: .all)?.first {
+                playlist = existing
+            } else {
+                playlist = createPlaylist(with: topLevelFolderName)
+            }
+
+            guard let safePlaylist = playlist, !safePlaylist.isReadOnly else { continue }
+
+            // Avoid duplicates
+            let alreadyContains = safePlaylist.media?.contains(where: { $0.identifier() == item.identifier() }) ?? false
+            if !alreadyContains {
+                _ = safePlaylist.appendMedia(withIdentifier: item.identifier())
+            }
+        }
+    }
+
+    func shouldExcludeFolderFromAutoPlaylist(_ folderName: String) -> Bool {
+        if folderName.hasPrefix(".") { return true }
+        switch folderName {
+        case "Inbox", "Logs", "MediaLibrary":
+            return true
+        default:
+            return false
         }
     }
 }


### PR DESCRIPTION
Automatically create playlists based on top-level folders to improve media organization.

This feature allows users to create folders in the app's Documents directory via their desktop OS, and the app will automatically generate corresponding playlists for all playable files within those folders. It hooks into `MediaLibraryService.didAddMedia` to detect new media, identifies the top-level folder, and creates/updates a playlist, while skipping system/hidden folders and preventing duplicates.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e87d538-2582-468a-bdd8-36edba4a2c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e87d538-2582-468a-bdd8-36edba4a2c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

